### PR TITLE
Update kanban board drag and drop

### DIFF
--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import React, { useState, type ReactNode } from "react";
 import {
 	DndContext,
 	DragEndEvent,
@@ -10,6 +10,7 @@ import {
 	useSensor,
 	useSensors,
 } from "@dnd-kit/core";
+import { useDroppable } from "@dnd-kit/core";
 import {
 	arrayMove,
 	SortableContext,
@@ -33,9 +34,12 @@ const statusColumns: { id: TaskStatus; title: string; color: string }[] = [
 ];
 
 export function KanbanBoard({ projectId, initialTasks }: KanbanBoardProps) {
-	const [tasks, setTasks] = useState<ITask[]>(initialTasks);
+	// Maintain tasks grouped by status for simpler reordering and cross-column moves
+	const [columns, setColumns] = useState<Record<TaskStatus, ITask[]>>(() => {
+		return groupTasksByStatus(initialTasks);
+	});
 	const [activeTask, setActiveTask] = useState<ITask | null>(null);
-	const [loading, setLoading] = useState(false);
+
 
 	const sensors = useSensors(
 		useSensor(PointerSensor, {
@@ -47,7 +51,7 @@ export function KanbanBoard({ projectId, initialTasks }: KanbanBoardProps) {
 
 	const handleDragStart = (event: DragStartEvent) => {
 		const { active } = event;
-		const task = tasks.find(t => t.id === active.id);
+		const task = getTaskById(Number(active.id));
 		setActiveTask(task || null);
 	};
 
@@ -57,38 +61,163 @@ export function KanbanBoard({ projectId, initialTasks }: KanbanBoardProps) {
 
 		if (!over) return;
 
-		const taskId = active.id as number;
-		const newStatus = over.id as TaskStatus;
-		console.log("newStatus", newStatus);
-		const task = tasks.find(t => t.id === taskId);
+		const activeId = Number(active.id);
+		const activeContainer = findContainerForId(activeId);
+		const overContainer = findContainerForOver(over.id);
 
-		if (!task || task.status === newStatus) return;
+		if (!activeContainer || !overContainer) return;
 
-		// Optimistic update
-		setTasks(prevTasks =>
-			prevTasks.map(t => (t.id === taskId ? { ...t, status: newStatus } : t))
-		);
+		// Reorder within the same column
+		if (activeContainer === overContainer) {
+			const activeIndex = columns[activeContainer].findIndex((t: ITask) => t.id === activeId);
+			let overIndex: number = activeIndex;
+			if (typeof over.id === "number") {
+				overIndex = columns[overContainer].findIndex((t: ITask) => t.id === over.id);
+			} else if (typeof over.id === "string") {
+				// Dropped into empty space of the same column; keep position
+				overIndex = activeIndex;
+			}
+
+			if (activeIndex !== overIndex && activeIndex !== -1 && overIndex !== -1) {
+				setColumns((prev: Record<TaskStatus, ITask[]>) => ({
+					...prev,
+					[activeContainer]: arrayMove<ITask>(prev[activeContainer], activeIndex, overIndex),
+				}));
+			}
+			return;
+		}
+
+		// Move to a different column
+		const sourceList = columns[activeContainer];
+		const taskIndex = sourceList.findIndex((t: ITask) => t.id === activeId);
+		if (taskIndex === -1) return;
+		const movedTask = sourceList[taskIndex];
+
+		let targetIndex = columns[overContainer].length; // default append
+		if (typeof over.id === "number") {
+			const idx = columns[overContainer].findIndex((t: ITask) => t.id === over.id);
+			if (idx !== -1) targetIndex = idx;
+		}
+
+		// Optimistic state update
+		setColumns((prev: Record<TaskStatus, ITask[]>) => {
+			const next: Record<TaskStatus, ITask[]> = {
+				...prev,
+				[activeContainer]: prev[activeContainer].filter((t: ITask) => t.id !== activeId),
+				[overContainer]: [
+					...prev[overContainer].slice(0, targetIndex),
+					{ ...movedTask, status: overContainer },
+					...prev[overContainer].slice(targetIndex),
+				],
+			};
+			return next;
+		});
 
 		try {
 			await TasksService.changeStatus({
 				projectId,
-				taskId: taskId.toString(),
-				newStatus,
+				taskId: String(activeId),
+				newStatus: overContainer,
 			});
 			toast.success("Task status updated");
-		} catch (error) {
+		} catch {
 			// Revert on error
-			setTasks(prevTasks =>
-				prevTasks.map(t =>
-					t.id === taskId ? { ...t, status: task.status } : t
-				)
-			);
+			setColumns((prev: Record<TaskStatus, ITask[]>) => {
+				// Move it back
+				const revertedTarget = prev[overContainer].filter((t: ITask) => t.id !== activeId);
+				const originalTask = { ...movedTask };
+				return {
+					...prev,
+					[overContainer]: revertedTarget,
+					[activeContainer]: [
+						...prev[activeContainer].slice(0, taskIndex),
+						originalTask,
+						...prev[activeContainer].slice(taskIndex),
+					],
+				};
+			});
 			toast.error("Failed to update task status");
 		}
 	};
 
-	const getTasksByStatus = (status: TaskStatus) => {
-		return tasks.filter(task => task.status === status);
+	const getTasksByStatus = (status: TaskStatus): ITask[] => {
+		return columns[status] ?? [];
+	};
+
+	const getTaskById = (taskId: number) => {
+		for (const status of Object.keys(columns) as TaskStatus[]) {
+			const task = columns[status].find((t: ITask) => t.id === taskId);
+			if (task) return task;
+		}
+		return undefined;
+	};
+
+	const findContainerForId = (id: number): TaskStatus | null => {
+		for (const status of Object.keys(columns) as TaskStatus[]) {
+			if (columns[status].some((t: ITask) => t.id === id)) return status;
+		}
+		return null;
+	};
+
+	const findContainerForOver = (overId: unknown): TaskStatus | null => {
+		if (typeof overId === "string") {
+			// over a column droppable
+			if (isKnownStatus(overId)) return overId as TaskStatus;
+		}
+		if (typeof overId === "number") {
+			return findContainerForId(overId);
+		}
+		return null;
+	};
+
+	function isKnownStatus(value: string): value is TaskStatus {
+		return (
+			value === "TODO" ||
+			value === "IN_PROGRESS" ||
+			value === "REVIEW" ||
+			value === "DONE" ||
+			value === "CANCELLED"
+		);
+	}
+
+	function groupTasksByStatus(all: ITask[]): Record<TaskStatus, ITask[]> {
+		const result: Record<TaskStatus, ITask[]> = {
+			TODO: [],
+			IN_PROGRESS: [],
+			REVIEW: [],
+			DONE: [],
+			CANCELLED: [],
+		};
+		for (const task of all) {
+			if (result[task.status]) {
+				result[task.status].push(task);
+			}
+		}
+		return result;
+	}
+
+	const KanbanColumn: React.FC<{
+		id: TaskStatus;
+		title: string;
+		color: string;
+		items: number[];
+		children: ReactNode;
+	}> = ({ id, title, color, items, children }) => {
+		const { setNodeRef } = useDroppable({ id });
+		return (
+			<div className='space-y-4'>
+				<div className={`p-3 rounded-lg ${color}`}>
+					<h3 className='font-semibold text-center'>
+						{title} ({items.length})
+					</h3>
+				</div>
+				<SortableContext items={items} strategy={verticalListSortingStrategy}>
+					<div ref={setNodeRef} className='space-y-3 min-h-[400px]'>
+						{children}
+					</div>
+				</SortableContext>
+			</div>
+		);
 	};
 
 	return (
@@ -101,23 +230,17 @@ export function KanbanBoard({ projectId, initialTasks }: KanbanBoardProps) {
 				{statusColumns.map(column => {
 					const columnTasks = getTasksByStatus(column.id);
 					return (
-						<div key={column.id} className='space-y-4'>
-							<div className={`p-3 rounded-lg ${column.color}`}>
-								<h3 className='font-semibold text-center'>
-									{column.title} ({columnTasks.length})
-								</h3>
-							</div>
-							<SortableContext
-								items={columnTasks.map(task => task.id)}
-								strategy={verticalListSortingStrategy}
-							>
-								<div className='space-y-3 min-h-[400px]'>
-									{columnTasks.map(task => (
-										<TaskCard key={task.id} task={task} />
-									))}
-								</div>
-							</SortableContext>
-						</div>
+						<KanbanColumn
+							key={column.id}
+							id={column.id}
+							title={column.title}
+							color={column.color}
+							items={columnTasks.map(task => task.id)}
+						>
+							{columnTasks.map(task => (
+								<TaskCard key={task.id} task={task} />
+							))}
+						</KanbanColumn>
 					);
 				})}
 			</div>


### PR DESCRIPTION
Implement drag-and-drop for kanban tasks to allow cross-column status changes and same-column reordering with optimistic UI updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-4761c49c-9ce6-4168-90ce-380f167ffe74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4761c49c-9ce6-4168-90ce-380f167ffe74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

