### PR TITLE
Filter assignees by kanban board visibility

### DIFF
--- a/src/app/projects/[projectId]/tasks/page.tsx
+++ b/src/app/projects/[projectId]/tasks/page.tsx
@@ -115,11 +115,19 @@ export default function ProjectTasksPage({ params }: Props) {
 
 	const prioritiesArr = Array.from(new Set(tasks.map(task => task.priority)));
 
-	const filter = tasks.filter(task =>
-		prioritiesArr.some(pr => pr === task.priority)
+	const shouldFilterAssigneesByRenderedTasks = Boolean(
+		searchParams.get("status") || searchParams.get("priority")
 	);
 
-	const assigneesArr = Array.from(new Set(assignees.map(asgn => asgn.name)));
+	const renderedAssigneeIdsSet = new Set(
+		tasks
+			.map(t => (t.assignedTo ?? t.assignee?.id) as number | undefined)
+			.filter((id): id is number => typeof id === "number")
+	);
+
+	const assigneesForSelect = shouldFilterAssigneesByRenderedTasks
+		? assignees.filter(a => renderedAssigneeIdsSet.has(a.id))
+		: assignees;
 
 	return (
 		<div className='space-y-6'>
@@ -170,7 +178,7 @@ export default function ProjectTasksPage({ params }: Props) {
 					}
 				>
 					<option value=''>All Assignees</option>
-					{assignees.map((a: { id: number; name: string }) => (
+					{assigneesForSelect.map((a: { id: number; name: string }) => (
 						<option key={a.id} value={a.id.toString()}>
 							{a.name}
 						</option>


### PR DESCRIPTION
Filter assignee select options to show only assignees from tasks currently visible on the Kanban board when filtered by status or priority.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb6d1155-ee18-4aa9-9978-db95f1d78bcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb6d1155-ee18-4aa9-9978-db95f1d78bcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

